### PR TITLE
Add Legizmo Kincaid

### DIFF
--- a/data/tweaks.json
+++ b/data/tweaks.json
@@ -733,5 +733,12 @@
         "issue": "-",
         "description": "Show weather info on lockscreen & stock weather app icon",
         "repo": "[Repo Of A Noob](https://tweak.mario.net.in)"
+    },
+    {
+        "name": "Legizmo 'Kincaid'",
+        "compatible": "✔️",
+        "issue": "-",
+        "description": "Pair unsupported Apple Watches",
+        "repo": "[Chariz](https://repo.chariz.com/)"
     }
 ]


### PR DESCRIPTION
The existing 4.0 release of Legizmo Kincaid is compatible with iOS 15, validated on iOS 15.4.1, 15.7.1 and 15.7.2